### PR TITLE
Change datapackage to datapack as the package was renamed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN rm -rf /tmp/*.rds \
     -r "http://packages.ropensci.org" \
     -r "http://www.bioconductor.org/packages/release/bioc" \
     -r "http://nceas.github.io/drat" \
-    datapackage \
+    datapack \
     dismo \
     drat \
     geiger \
@@ -40,7 +40,6 @@ RUN rm -rf /tmp/*.rds \
     RJSONIO \
     sangerseqR \
     dataone \
-    datapackage \
   && installGithub.r \
     richfitz/drat.builder \
     cloudyr/aws.signature \


### PR DESCRIPTION
@cboettig This is a simple PR to change 'datapackage' to 'datapack', and eliminate duplication. 
